### PR TITLE
Combine functions and generate prefix-less property

### DIFF
--- a/properties.less
+++ b/properties.less
@@ -1,3 +1,3 @@
-.property(@property, @value, @prefixes:"") {
-  -ig: ~`(function(){var a=@{prefixes}.split(/\s+/),r='nore',i=0;a.push('');for(;i<a.length;++i)r+=";\n  -"+a[i]+"-"+"@{property}: "+"@{value}";return r})()`;
+.property(@property, @value, @prefixes: "", @base: true) {
+  -ig: ~`(function(){var a=@{prefixes}.split(/\s+/),r='nore',i=0;@{base}&&a.push('');for(;i<a.length;++i)b=a[i],r+=";\n  "+(b?"-"+b+"-":b)+"@{property}: "+"@{value}";return r})()`;
 }


### PR DESCRIPTION
Before you, have to call .property twice to get the full set of properties when doing stuff like:

``` css
-webkit-transform: rotate(90deg);
-moz-transform: rotate(90deg);
-o-transform: rotate(90deg);
transform: rotate(90deg);
```

Would require:

``` css
.property(transform, rotate(90deg), "webkit moz o");
transform: rotate(90deg);
```

With this change, the second line can be omitted and just:

``` css
.property(transform, rotate(90deg), "webkit moz o");
```

will generate the necessary CSS.

Additionally, I shortened the `-less-property: none;` to `-ig: nore` just to save characters on the outputted css. It is ignored in all the browsers I tested and is fine in LESS 1.3.0.

I will update your README.md to reflect the change if you want to accept the pull.
