### PR TITLE
Fixing a small bug

### DIFF
--- a/properties.less
+++ b/properties.less
@@ -1,3 +1,3 @@
 .property(@property, @value, @prefixes: '', @base: true) {
-  -less-property: ~`(function(){var a=@{prefixes}.split(/\s+/),r=' property',i=0;@{base}&&@{prefixes}&&a.push('');for(;i<a.length;++i)b=a[i],r+=';\n  '+(b?'-'+b+'-':b)+'@{property}: '+'@{value}';return r})()`;
+  -less-property: ~`(function(){var a=@{prefixes}.split(/\s+/),r=' property',i=0,v='@{value}';@{base}&&@{prefixes}&&a.push('');/^\[.+]$/.test(v)&&(v=v.replace(/(^\[|]$)/g,'').replace(/, /g,function(m,o,s){var i=s.indexOf('(',o),j=s.indexOf(')',o);return j+1&&(i<0||j<i)?m:' ';}));for(;i<a.length;++i)b=a[i],r+=';\n  '+(b?'-'+b+'-':b)+'@{property}: '+v;return r})()`;
 }


### PR DESCRIPTION
Where using `.property` like:

``` css
.property(user-select, none);
```

would generate:

``` css
-less-property:  property;
user-select: none;
user-select: none;
```

This change fixes it.
